### PR TITLE
change reserved_peers option to be a path rather than a list

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -140,7 +140,7 @@ class Editor extends Component {
           { this.number('network', 'id', !isOffline) }
           { this.list('network', 'bootnodes', !isOffline) }
           { this.flag('network', 'discovery', !isOffline) }
-          { this.list('network', 'reserved_peers', !isOffline) }
+          { this.path('network', 'reserved_peers', base, platform, !isOffline) }
           { this.flag('network', 'reserved_only', !isOffline) }
           { this.select('network', 'allow_ips', !isOffline) }
           { this.flag('network', 'no_ancient_blocks', !isOffline) }

--- a/src/data.json
+++ b/src/data.json
@@ -252,7 +252,7 @@
     "reserved_peers": {
       "name": "Reserved Peers Path",
       "description": "Specify a path to a file with peers' enodes to be always connected to.",
-      "default": [""]
+      "default": ""
     },
     "reserved_only": {
       "name": "Reserved Only", 


### PR DESCRIPTION
When playing around with this option I noticed that the config generator creates an invalid line that causes parity to complain:

> You might have supplied invalid parameters in config file.
> invalid type: sequence, expected a string for key `network.reserved_peers`

I haven't tested building the project with this change so there may be a bug, but I think the syntax is right.