### PR TITLE
Warn user of malformed config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -313,16 +313,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "create-react-class": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
-      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
-      "requires": {
-        "fbjs": "0.8.14",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -392,6 +382,11 @@
         "rimraf": "2.6.1"
       }
     },
+    "dialog-polyfill": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.4.9.tgz",
+      "integrity": "sha512-iM4ZXRLOA/qpbW6XznGOq7Iq58JoXhZGo+OMG8K3wFxvIatnMTnIancLGEKa6WYy6oTkndfb2UXQ6FGtoUBn1g=="
+    },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -407,7 +402,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.18"
+        "iconv-lite": "0.4.19"
       }
     },
     "error-ex": {
@@ -734,9 +729,9 @@
       "dev": true
     },
     "fbjs": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
-      "integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
         "core-js": "1.2.7",
         "isomorphic-fetch": "2.2.1",
@@ -744,7 +739,7 @@
         "object-assign": "4.1.1",
         "promise": "7.3.1",
         "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.14"
+        "ua-parser-js": "0.7.17"
       }
     },
     "figures": {
@@ -806,6 +801,951 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
+      "integrity": "sha1-VY6Mw4ZD2O9A/kUVhIbQ0ldY7uQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.6.29"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.1.4"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bl": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "readable-stream": "2.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              }
+            }
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.0"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "1.0.0-rc4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "1.5.2",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.11"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.4",
+            "inherits": "2.0.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.5.3"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.10",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.2"
+          }
+        },
+        "gauge": {
+          "version": "2.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.0.4",
+            "console-control-strings": "1.1.0",
+            "has-color": "0.1.7",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.0",
+            "signal-exit": "3.0.0",
+            "string-width": "1.0.1",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.0"
+          }
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-property": "1.0.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.2",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.9.0",
+            "is-my-json-valid": "2.13.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "2.0.0"
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.3.0",
+            "sshpk": "1.8.3"
+          }
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.3.3",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.0"
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.13.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "jsonpointer": "2.0.0",
+            "xtend": "4.0.1"
+          }
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonpointer": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.2",
+            "verror": "1.3.6"
+          }
+        },
+        "mime-db": {
+          "version": "1.23.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.23.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.5"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "3.1.2",
+            "rc": "1.1.6",
+            "request": "2.73.0",
+            "rimraf": "2.5.3",
+            "semver": "5.2.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.1.4"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          }
+        },
+        "npmlog": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.2",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.6.0",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "qs": {
+          "version": "6.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.1",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "1.0.4"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.1",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.73.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.4.1",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.0-rc4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.11",
+            "node-uuid": "1.4.7",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.0",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.2",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.0.5"
+          }
+        },
+        "semver": {
+          "version": "5.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.8.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "dashdash": "1.14.0",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.6",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.0",
+            "tweetnacl": "0.13.3"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.0.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "bundled": true,
+          "dev": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.10",
+            "inherits": "2.0.1"
+          }
+        },
+        "tar-pack": {
+          "version": "3.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.2.0",
+            "fstream": "1.0.10",
+            "fstream-ignore": "1.0.5",
+            "once": "1.3.3",
+            "readable-stream": "2.1.4",
+            "rimraf": "2.5.3",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.13.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.0",
@@ -911,9 +1851,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
       "version": "3.3.3",
@@ -1088,7 +2028,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.1",
+        "node-fetch": "1.7.3",
         "whatwg-fetch": "2.0.3"
       }
     },
@@ -1240,6 +2180,13 @@
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
+    "nan": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1247,9 +2194,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -1479,35 +2426,35 @@
       }
     },
     "prop-types": {
-      "version": "15.5.10",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
       "requires": {
-        "fbjs": "0.8.14",
-        "loose-envify": "1.3.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "react": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
-      "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "requires": {
-        "create-react-class": "15.6.0",
-        "fbjs": "0.8.14",
+        "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.1"
       }
     },
     "react-dom": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
-      "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
       "requires": {
-        "fbjs": "0.8.14",
+        "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.1"
       }
     },
     "react-scripts": {
@@ -1546,6 +2493,7 @@
         "filesize": "3.3.0",
         "find-cache-dir": "0.1.1",
         "fs-extra": "0.30.0",
+        "fsevents": "1.0.14",
         "gzip-size": "3.0.0",
         "html-loader": "0.4.3",
         "html-webpack-plugin": "2.22.0",
@@ -2853,6 +3801,7 @@
           "requires": {
             "anymatch": "1.3.0",
             "async-each": "1.0.1",
+            "fsevents": "1.0.14",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -8612,9 +9561,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
-      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
     "uniq": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "dialog-polyfill": "^0.4.9",
     "getmdl-select": "^1.1.0",
     "lodash.isequal": "^4.5.0",
     "material-design-lite": "^1.3.0",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "prop-types": "^15.6.1",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -113,11 +113,12 @@ class App extends Component {
 
     let modal;
     if (!errors.length) {
-      modal = {};
+      modal = {visible: false};
     } else {
       let lis = errors.map(({section, prop, value, type, expected}, i) =>
         (<li key={i}><em>{section}.{prop}</em> has value <em>{JSON.stringify(value)}</em> of type <em>{type}</em>; expected type <em>{expected}</em></li>));
       modal = {
+        visible: true,
         title: 'Warning',
         content: (
           <Fragment>
@@ -169,7 +170,7 @@ class App extends Component {
             </div>
           </div>
         </main>
-        <Modal title={modal.title} reset={() => this.setState({modal: {}})}>
+        <Modal title={modal.title} isOpen={modal.visible} onClose={() => this.setState({modal: {visible: false}})}>
           {modal.content}
         </Modal>
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -54,12 +54,19 @@ function loadSettings () {
       Object.keys(defaultSettings).forEach(key => {
         settings[key] = settings[key] || {};
         Object.keys(defaultSettings[key]).forEach(prop => {
-          if (settings[key][prop] === undefined) {
-            settings[key][prop] = defaultSettings[key][prop];
-          } else if (typeof settings[key][prop] !== typeof defaultSettings[key][prop]) {
-            errors.push({section: key, prop, value: settings[key][prop], type: typeof settings[key][prop], expected: typeof defaultSettings[key][prop]});
-            console.error(`Incorrect type for config item ${key}.${prop} with value ${JSON.stringify(settings[key][prop])} (found ${typeof settings[key][prop]}, expected ${typeof defaultSettings[key][prop]})`);
-            settings[key][prop] = defaultSettings[key][prop];
+          let settingsValue = settings[key][prop];
+          let defaultSettingsValue = defaultSettings[key][prop];
+          if (settingsValue === undefined) {
+            settings[key][prop] = defaultSettingsValue;
+          } else if (typeof settingsValue !== typeof defaultSettingsValue) {
+            errors.push({
+              section: key,
+              prop,
+              value: settingsValue,
+              type: typeof settingsValue,
+              expected: typeof defaultSettingsValue});
+            console.error(`Incorrect type for config item ${key}.${prop} with value ${JSON.stringify(settingsValue)} (found ${typeof settingsValue}, expected ${typeof defaultSettingsValue})`);
+            settings[key][prop] = defaultSettingsValue;
           }
         });
       });

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import Section from './Section';
 import Item from './Item';

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const stylesNormal = {overflow: 'visible'};
 const stylesLarge = {overflow: 'visible', height: 'auto'};

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,0 +1,6 @@
+dialog.mdl-dialog {
+    width: 60%;
+    z-index: 10;
+    top: 50%;
+    transform: translateY(-50%);
+}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -28,7 +28,8 @@ class Modal extends Component {
     }
 
     if (this.props.title) {
-      setTimeout(this.show.bind(this), 100);
+      // Delay is a workaround for paint issue (modal overlay not showing up)
+      setTimeout(() => { this.show(); }, 100);
     }
   }
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+import dialogPolyfill from 'dialog-polyfill/dialog-polyfill.js';
+import 'dialog-polyfill/dialog-polyfill.css';
+import './Modal.css';
+
+class Modal extends Component {
+
+  static propTypes = {
+    title: PropTypes.string,
+    reset: PropTypes.func.isRequired,
+    children: PropTypes.object
+  };
+
+  close () {
+    ReactDOM.findDOMNode(this).close();
+  }
+
+  show () {
+    ReactDOM.findDOMNode(this).showModal();
+  }
+
+  componentDidMount () {
+    const dialog = ReactDOM.findDOMNode(this);
+    if (!dialog.showModal) {
+      dialogPolyfill.registerDialog(dialog);
+    }
+
+    if (this.props.title) {
+      setTimeout(this.show.bind(this), 100);
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.title && !this.props.title) {
+      this.close();
+    } else if (!prevProps.title && this.props.title) {
+      this.show();
+    }
+  }
+
+  render () {
+    return (
+      <dialog className='mdl-dialog'>
+        <h4 className='mdl-dialog__title'>{this.props.title}</h4>
+        <div className='mdl-dialog__content'>
+          {this.props.children}
+        </div>
+        <div className='mdl-dialog__actions'>
+          <button type='button' className='mdl-button close' onClick={this.props.reset}>OK</button>
+        </div>
+      </dialog>
+    );
+  }
+}
+
+export default Modal;

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -8,8 +8,9 @@ import './Modal.css';
 class Modal extends Component {
 
   static propTypes = {
+    isOpen: PropTypes.bool,
     title: PropTypes.string,
-    reset: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
     children: PropTypes.object
   };
 
@@ -27,16 +28,16 @@ class Modal extends Component {
       dialogPolyfill.registerDialog(dialog);
     }
 
-    if (this.props.title) {
+    if (this.props.isOpen) {
       // Delay is a workaround for paint issue (modal overlay not showing up)
       setTimeout(() => { this.show(); }, 100);
     }
   }
 
   componentDidUpdate (prevProps) {
-    if (prevProps.title && !this.props.title) {
+    if (prevProps.isOpen && !this.props.isOpen) {
       this.close();
-    } else if (!prevProps.title && this.props.title) {
+    } else if (!prevProps.isOpen && this.props.isOpen) {
       this.show();
     }
   }
@@ -49,7 +50,7 @@ class Modal extends Component {
           {this.props.children}
         </div>
         <div className='mdl-dialog__actions'>
-          <button type='button' className='mdl-button close' onClick={this.props.reset}>OK</button>
+          <button type='button' className='mdl-button close' onClick={this.props.onClose}>OK</button>
         </div>
       </dialog>
     );

--- a/src/components/Modal.test.js
+++ b/src/components/Modal.test.js
@@ -1,0 +1,9 @@
+/* global it */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Modal from './Modal';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Modal />, div);
+});

--- a/src/components/Presets/Presets.js
+++ b/src/components/Presets/Presets.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import './Presets.css';
 

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,5 +1,6 @@
 /* global Blob */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import './Preview.css';
 
 import { joinPath, basePath } from '../system';

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import './Section.css';
 

--- a/src/components/controls/Select.js
+++ b/src/components/controls/Select.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 function Select ({value, onChange, values, id, disabled}) {


### PR DESCRIPTION
closes #35 

Previous behaviour : when loading a config where the types don't match with the current format, parity-config-generator might crash because it assumes the types are correct (for displaying in the editor for example). Example: http://paritytech.github.io/parity-config-generator/#config=eyJuZXR3b3JrIjp7InJlc2VydmVkX3BlZXJzIjpbImZpcnN0cGF0aCIsInNlY29uZHBhdGgiXX19 This can happen if the type of an item changed with a commit, like in https://github.com/paritytech/parity-config-generator/commit/874133549b5d998bcbdadcc2c16e587ab5f4dc8a

This PR instead displays a warning (to make sure the user knows that the setting will be ignored) and sets the malformed config item to the default value. Added a Modal component and updated React dependency to be able to use `<Fragment>` (with the new version, PropTypes have been moved to a separate repo).

![image](https://user-images.githubusercontent.com/5739676/36859425-914d92a4-1d7e-11e8-9137-f8403a5e2f54.png)
