### PR TITLE
use fs.promises for recent nodejs version

### DIFF
--- a/scripts/generate-config-data.js
+++ b/scripts/generate-config-data.js
@@ -268,12 +268,15 @@ function generateAugmentedData (source, extra) {
   return augment(data, extra);
 }
 
+async function fetchExtraData(){
+  return JSON.parse(await fs.readFile(path.resolve(__dirname, '../src/data.extra.json'), 'UTF-8'));
+}
+
 if (!module.parent) {
   (async function () {
   // Make sure that config items with unrecognized default values
   // were set a default value in data.extra.json
-    const extra = JSON.parse(await fs.readFile(path.resolve(__dirname, '../src/data.extra.json'), 'UTF-8'));
-    const dataAugmented = generateAugmentedData(await fetchSource(), extra);
+    const dataAugmented = generateAugmentedData(await fetchSource(), await fetchExtraData());
   
 
     Object.keys(dataAugmented).forEach(section => {
@@ -299,6 +302,7 @@ if (!module.parent) {
 } else {
   module.exports = {
     fetchSource: fetchSource,
+    fetchExtra: fetchExtraData,
     getCliOptions: getCliOptions,
     getData: generateAugmentedData
   };

--- a/scripts/generate-config-data.js
+++ b/scripts/generate-config-data.js
@@ -1,5 +1,5 @@
 const https = require('https');
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const bl = require('bl');
 
@@ -240,7 +240,7 @@ function augment (data, extra) {
   return dataAugmentedOrdered;
 }
 
-function generateAugmentedData (source) {
+function generateAugmentedData (source, extra) {
   // Parse CLI options
 
   const cliOptions = getCliOptions(source);
@@ -265,7 +265,6 @@ function generateAugmentedData (source) {
 
   // Augment with data.extra.json
 
-  const extra = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../src/data.extra.json'), 'UTF-8'));
   return augment(data, extra);
 }
 
@@ -273,8 +272,9 @@ if (!module.parent) {
   (async function () {
   // Make sure that config items with unrecognized default values
   // were set a default value in data.extra.json
-
-    const dataAugmented = generateAugmentedData(await fetchSource());
+    const extra = JSON.parse(await fs.readFile(path.resolve(__dirname, '../src/data.extra.json'), 'UTF-8'));
+    const dataAugmented = generateAugmentedData(await fetchSource(), extra);
+  
 
     Object.keys(dataAugmented).forEach(section => {
       const undefinedDefaults = Object.keys(dataAugmented[section])
@@ -291,7 +291,7 @@ if (!module.parent) {
 
   // Write to file
 
-    fs.writeFileSync(path.resolve(__dirname, '../src/data.compiled.json'), JSON.stringify(dataAugmented, null, 2));
+    await fs.writeFile(path.resolve(__dirname, '../src/data.compiled.json'), JSON.stringify(dataAugmented, null, 2));
   })().catch(e => {
     console.error(e);
     process.exit(1);

--- a/scripts/generate-config-docs.js
+++ b/scripts/generate-config-docs.js
@@ -93,7 +93,7 @@ async function buildPage () {
   const source = await data.fetchSource();
   const extra =  JSON.parse(fs.readFileSync(path.resolve(__dirname, '../src/data.extra.json'), 'UTF-8'));
   compiledBuffer.append(docTemplate.preExampleConfig);
-  compiledBuffer.append(compiledToml(data.getData(source)));
+  compiledBuffer.append(compiledToml(data.getData(source, extra)));
   compiledBuffer.append(docTemplate.postExampleConfig);
   compiledBuffer.append(docTemplate.preConfigDoc);
   compiledBuffer.append(compiledMd(data.getCliOptions(source)));

--- a/scripts/generate-config-docs.js
+++ b/scripts/generate-config-docs.js
@@ -91,6 +91,7 @@ function compiledMd (cliOptions) {
 async function buildPage () {
   var compiledBuffer = new BufferList();
   const source = await data.fetchSource();
+  const extra =  JSON.parse(fs.readFileSync(path.resolve(__dirname, '../src/data.extra.json'), 'UTF-8'));
   compiledBuffer.append(docTemplate.preExampleConfig);
   compiledBuffer.append(compiledToml(data.getData(source)));
   compiledBuffer.append(docTemplate.postExampleConfig);

--- a/scripts/generate-config-docs.js
+++ b/scripts/generate-config-docs.js
@@ -91,7 +91,7 @@ function compiledMd (cliOptions) {
 async function buildPage () {
   var compiledBuffer = new BufferList();
   const source = await data.fetchSource();
-  const extra =  JSON.parse(fs.readFileSync(path.resolve(__dirname, '../src/data.extra.json'), 'UTF-8'));
+  const extra =  await data.fetchExtra();
   compiledBuffer.append(docTemplate.preExampleConfig);
   compiledBuffer.append(compiledToml(data.getData(source, extra)));
   compiledBuffer.append(docTemplate.postExampleConfig);


### PR DESCRIPTION
Somehow this script was working on my local environment before this change- but didn't run on the docker image. this change uses fs.promises to make the script work again... I guess I should have just used utils.promisify? I have no idea how this worked (and is working on my local system) before this change. 

thanks to @TriplEight for pointing out the previous script was broken.