### PR TITLE
fix script failure and update data

### DIFF
--- a/scripts/generate-config-data.js
+++ b/scripts/generate-config-data.js
@@ -133,12 +133,14 @@ function getStructFields (name, source) {
 
   const fields = subsource.split('\n').slice(1, -1).filter(s => s.trim() && !s.trim().startsWith('#') && !s.trim().startsWith('_legacy'));
 
-  const parsedFields = fields.map(line => {
+  const parsedFields = fields.reduce( function (out, line){
     const matches = line.match(/^\s*(\w+): Option<([\w<>]+)>,$/);
-    const [, name, type] = matches;
-    return {name, type};
-  });
-
+    if (!(matches == null)){
+      const [, name, type] = matches;
+      out.push({name, type});
+    }
+    return out;
+  }, []);
   return parsedFields;
 }
 

--- a/scripts/generate-config-data.js
+++ b/scripts/generate-config-data.js
@@ -133,7 +133,7 @@ function getStructFields (name, source) {
 
   const fields = subsource.split('\n').slice(1, -1).filter(s => s.trim() && !s.trim().startsWith('#') && !s.trim().startsWith('_legacy'));
 
-  const parsedFields = fields.reduce( function (out, line){
+  const parsedFields = fields.reduce((out, line) => {
     const matches = line.match(/^\s*(\w+): Option<([\w<>]+)>,$/);
     if (matches !== null) {
       const [, name, type] = matches;

--- a/scripts/generate-config-data.js
+++ b/scripts/generate-config-data.js
@@ -135,7 +135,7 @@ function getStructFields (name, source) {
 
   const parsedFields = fields.reduce( function (out, line){
     const matches = line.match(/^\s*(\w+): Option<([\w<>]+)>,$/);
-    if (matches != null){
+    if (matches !== null) {
       const [, name, type] = matches;
       out.push({name, type});
     }

--- a/scripts/generate-config-data.js
+++ b/scripts/generate-config-data.js
@@ -135,7 +135,7 @@ function getStructFields (name, source) {
 
   const parsedFields = fields.reduce( function (out, line){
     const matches = line.match(/^\s*(\w+): Option<([\w<>]+)>,$/);
-    if (!(matches == null)){
+    if (matches != null){
       const [, name, type] = matches;
       out.push({name, type});
     }

--- a/src/data.compiled.json
+++ b/src/data.compiled.json
@@ -935,7 +935,7 @@
     },
     "tx_queue_locals": {
       "name": "Local Accounts",
-      "type": "hashset<string>",
+      "type": "string[]",
       "description": "Specify local accounts for which transactions are prioritized in the queue. ACCOUNTS is a comma-delimited list of addresses.",
       "default": [
         ""

--- a/src/data.compiled.json
+++ b/src/data.compiled.json
@@ -243,12 +243,6 @@
       "description": "Specify the cache time of accounts read from disk. If you manage thousands of accounts set this to 0 to disable refresh.",
       "default": 5
     },
-    "disable_hardware": {
-      "name": "Disable hardware",
-      "type": "bool",
-      "description": "Disables hardware wallet support.",
-      "default": false
-    },
     "fast_unlock": {
       "name": "Fast unlock",
       "type": "bool",
@@ -459,7 +453,8 @@
         "traces",
         "rpc",
         "shh",
-        "shh_pubsub"
+        "shh_pubsub",
+        "parity_transactions_pool"
       ],
       "values": [
         "Web3 [web3]",
@@ -580,7 +575,8 @@
         "traces",
         "rpc",
         "shh",
-        "shh_pubsub"
+        "shh_pubsub",
+        "parity_transactions_pool"
       ],
       "values": [
         "Web3 [web3]",
@@ -639,7 +635,8 @@
         "traces",
         "rpc",
         "shh",
-        "shh_pubsub"
+        "shh_pubsub",
+        "parity_transactions_pool"
       ],
       "values": [
         "Web3 [web3]",
@@ -936,6 +933,14 @@
       "min": 0,
       "max": 1000
     },
+    "tx_queue_locals": {
+      "name": "Local Accounts",
+      "type": "hashset<string>",
+      "description": "Specify local accounts for which transactions are prioritized in the queue. ACCOUNTS is a comma-delimited list of addresses.",
+      "default": [
+        ""
+      ]
+    },
     "tx_queue_ban_time": {
       "name": "Ban For",
       "type": "number",
@@ -1068,6 +1073,12 @@
       "type": "string",
       "description": " Stratum Server will listen for connections on IP {}.",
       "default": "local"
+    },
+    "disable": {
+      "name": "Disable Stratum",
+      "type": "bool",
+      "description": "For backwards compatibility; stratum is enabled if the config file contains a `[stratum]` section, and it is not explicitly disabled (disable = true)",
+      "default": "false"
     },
     "section": "Stratum (since 1.6)",
     "secret": {
@@ -1276,7 +1287,7 @@
     "unsafe_expose": {
       "name": "Unsafe expose",
       "type": "bool",
-      "description": "All servers will listen on external interfaces and will be remotely accessible. It's equivalent with setting the following: --[ws,jsonrpc,ui,ipfs-api,secretstore,stratum,dapps,secretstore-http]-interface=all --*-hosts=all    This option is UNSAFE and should be used with great care!",
+      "description": "All servers will listen on external interfaces and will be remotely accessible. It's equivalent with setting the following: --[ws,jsonrpc,ipfs-api,secretstore,stratum,dapps,secretstore-http]-interface=all --*-hosts=all    This option is UNSAFE and should be used with great care!",
       "default": false
     },
     "description": "Other uncategorized options."

--- a/src/data.compiled.json
+++ b/src/data.compiled.json
@@ -936,7 +936,7 @@
     "tx_queue_locals": {
       "name": "Local Accounts",
       "type": "string[]",
-      "description": "Specify local accounts for which transactions are prioritized in the queue. ACCOUNTS is a comma-delimited list of addresses.",
+      "description": "Specify local accounts for which transactions are prioritized in the queue.",
       "default": [
         ""
       ]

--- a/src/data.extra.json
+++ b/src/data.extra.json
@@ -607,6 +607,7 @@
       "max": 1000
     },
     "tx_queue_locals": {
+      "type":"string[]",
       "name": "Local Accounts",
       "description": "Specify local accounts for which transactions are prioritized in the queue. ACCOUNTS is a comma-delimited list of addresses.",
       "default": [

--- a/src/data.extra.json
+++ b/src/data.extra.json
@@ -609,7 +609,7 @@
     "tx_queue_locals": {
       "type":"string[]",
       "name": "Local Accounts",
-      "description": "Specify local accounts for which transactions are prioritized in the queue. ACCOUNTS is a comma-delimited list of addresses.",
+      "description": "Specify local accounts for which transactions are prioritized in the queue.",
       "default": [
         ""
       ]

--- a/src/data.extra.json
+++ b/src/data.extra.json
@@ -606,6 +606,13 @@
       "min": 0,
       "max": 1000
     },
+    "tx_queue_locals": {
+      "name": "Local Accounts",
+      "description": "Specify local accounts for which transactions are prioritized in the queue. ACCOUNTS is a comma-delimited list of addresses.",
+      "default": [
+        ""
+      ]
+    },
     "tx_queue_ban_time": {
       "name": "Ban For",
       "description": "Parity will ban senders/code for {} seconds.",
@@ -662,6 +669,11 @@
     "interface": {
       "name": "Interface",
       "description": " Stratum Server will listen for connections on IP {}."
+    },
+    "disable": {
+      "name":"Disable Stratum",
+      "description":"For backwards compatibility; stratum is enabled if the config file contains a `[stratum]` section, and it is not explicitly disabled (disable = true)",
+      "default":"false"
     }
   },
   "footprint": {


### PR DESCRIPTION
a couple of `scripts/` are called in parity-ethereum to autogen docs, some new config values in the parity-ethereum codebase are causing `generate-config-data.js` to fail currently.

Updated some of `data.extra.json` and made `generate-config-data.js` less strict - if we want to enforce a format for cli arguments/config params, it should probably be a part of parity-ethereum's tests instead of in here? 